### PR TITLE
Cap results returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,45 @@
 A file finder written in Go for my needs.
 
 Uses a worker pool to search through directory trees quicker and take advantage of multi-core machines.
-Go concurrencly allows it to run on single core machines.
+Go concurrency allows it to run on single core machines.
 
-## Goal
-The goal is to write this to use a worker pool but currently it spins up a go routine
-for each directory within the starting directory and then linearly searches each sub-directory 
+If you're looking for something specific you can limit the number of responses
 
 ### Features
-Concurrency which may speed up or slow down the search depending on the tree structure. 
-Common paths are ignored to save time and checks, such as `node_modules`, `.git`, and python `venv`.
-Searches for a pattern using basic sub-string
+ - Concurrency which may speed up or slow down the search depending on the tree structure. 
+ - Common paths are ignored to save time and checks, such as `node_modules`, `.git`, and python `venv`.
+ - Searches for a pattern using basic sub-string
 
 ## Warning
 > **warning**
-> Does not work on windows and I'm not trying to
+> Does not work on windows and I'm not trying too support this
 
 ## TODO
  - sub command to print paths that are ignored
  - create case sensative/insensative searching
- - can we create a worker pool instead of the number of initial directories
+ - add the ability exclude additional directories or patters
+ - add the ability to include specific patterns in the search path
+ - switch to ignore hidden files/directories
+ - [x] can we create a worker pool instead of the number of initial directories
+ - [x] cap the number of returned responses, say 1 (quit after the first match!)
+ - cap the depth of the search
 
 ## Using
-build with `go build -o find` and run with `./find -d <starting-path> -p <pattern-to-match-on>`
+### Build
+build with `go build -o gf main.go` and run with `./gf -d <starting-path> -p <pattern-to-match-on>`
 
+### Flags
+Customise your search with the following flags
 ```bash
+Usage of ./gf:
+  -c int
+    	The maximum number of results to find (default -1)
   -d string
-     The starting directory to check for files (default ".")
-  -j int
-     Estimated number of workers? (default 4)
+    	The starting directory to check for files (default ".")
   -p string
-     A pattern to check for within the file names
+    	A pattern to check for within the file names
+  -q int
+    	The max work queue size (default 2048)
+  -w int
+    	Number of workers (default 8)
 ```

--- a/main.go
+++ b/main.go
@@ -19,13 +19,14 @@ var IGNORE_PATHS = [7]string{
 }
 
 func main() {
-    //The number of workers. If there are more workers the system can read from
-    //the work queue more often and a larger queue is not required. It's a blance
-	jobs := flag.Int("j", 4, "Estimated number of workers?")
-    //If this is reached the system could end up in deadlock
-    //The bigger the queue size the more memory is used
-    //Smaller could be faster but you coud have deadlock
-	queueSize := flag.Int("q", 128, "The max work queue size")
+	//The number of workers. If there are more workers the system can read from
+	//the work queue more often and a larger queue is not required. It's a blance
+	workers := flag.Int("w", 8, "Number of workers")
+	//If this is reached the system could end up in deadlock
+	//The bigger the queue size the more memory is used
+	//Smaller could be faster but you coud have deadlock
+	queueSize := flag.Int("q", 2048, "The max work queue size")
+	maxResults := flag.Int("c", -1, "The maximum number of results to find")
 	dir := flag.String("d", ".", "The starting directory to check for files")
 	pattern := flag.String("p", "", "A pattern to check for within the file names")
 	flag.Parse()
@@ -41,21 +42,36 @@ func main() {
 		*dir = string((*dir)[0 : len(*dir)-1])
 	}
 
-	printCh := make(chan string, *jobs)
-    //The system will reach deadlock if the work queue reaches capacity
+	printCh := make(chan string, *workers)
+	//The system will reach deadlock if the work queue reaches capacity
 	workQ := make(chan string, *queueSize)
 	dirCount := make(chan int)
 	//Track how many dirs are open and close the work queue when we hit zero
 	go dirChecker(dirCount, workQ)
 	defer close(dirCount)
-	go createWorkerPool(pattern, workQ, printCh, dirCount, jobs)
+	go createWorkerPool(pattern, workQ, printCh, dirCount, workers)
 
 	//Send first work request
 	workQ <- *dir
 
 	//Print all results
-	for item := range printCh {
-		fmt.Println(item)
+	showResults(printCh, maxResults)
+}
+
+func showResults(ch chan string, limit *int) {
+	if *limit > 0 {
+		n := 0
+		for item := range ch {
+			fmt.Println(item)
+			n++
+			if n >= *limit {
+				return
+			}
+		}
+	} else {
+		for item := range ch {
+			fmt.Println(item)
+		}
 	}
 }
 
@@ -99,9 +115,9 @@ func search(pattern *string, in chan string, out chan string, cnt chan int) {
 						continue ItemSearch
 					}
 				}
-                subPath := fmt.Sprintf("%s/%s", path, item.Name())
+				subPath := fmt.Sprintf("%s/%s", path, item.Name())
 				cnt <- 1
-                in <- subPath
+				in <- subPath
 			} else {
 				if strings.Index(item.Name(), *pattern) >= 0 {
 					//subPath is repeated but no point in creating an allocation if not required


### PR DESCRIPTION
Let users decide how many results they want to see. 

Quit after the first one? `-c 1` defaults to showing all possible results. 