### PR TITLE
FEAT: Allow positional arguments

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,7 +22,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.21
+        go-version: '>=1.21.0'
+        cache: true
 
     - name: Build the project
       run: go build -v ./...

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -16,11 +16,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - run: git fetch --force --tags
+
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.21.0'
           cache: true
+
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
       - uses: goreleaser/goreleaser-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 # Generic build command removing CGO and debugging info for smaller release
 build:
-	CGO_ENABLED=0 go build -o gf -ldflags="-s -w" main.go
+	CGO_ENABLED=0 go build -o gof -ldflags="-s -w" ./*.go
+
+# Format code
+fmt:
+	go fmt ./...
+
+# check the code for mistakes
+lint:
+	go vet ./...
 
 #This will build the binary specifically for newer x86-64 machines. It assumes the CPU
 #is newer like most modern desktop cpus, hence amd64 lvl v3
@@ -8,4 +16,4 @@ build:
 # With a small program like this we likely won't see a speedup but I like the opporunity
 # to go fast
 buildx86:
-	GOARCH=amd64 GOAMD64="v3" CGO_ENABLED=0 go build -o gf -ldflags="-s -w" main.go
+	GOARCH=amd64 GOAMD64="v3" CGO_ENABLED=0 go build -o gof -ldflags="-s -w" ./*.go

--- a/README.md
+++ b/README.md
@@ -1,34 +1,42 @@
 # Go Find
-A file finder written in Go for my needs.
+A file finder written in Go.
 
-Uses a worker pool to search through directory trees quicker and take advantage of multi-core machines.
-Go concurrency allows it to run on single core machines.
-
-If you're looking for something specific you can limit the number of responses
+Uses a worker pool to search through directory trees quicker by taking advantage of multi-core machines.
+Go concurrency allows it to run on single core machines. 
 
 ### Features
- - Concurrency which may speed up or slow down the search depending on the tree structure. 
+ - Concurrency search directories for desired pattern
+ - Exit early with a max results option
  - Common paths are ignored to save time and checks, such as `node_modules`, `.git`, and python `venv`.
  - Searches for a pattern using basic sub-string
+ - Use a worker pool to avoid spinning up too many go routines if there are _many_ directories
 
 ## Warning
 > **warning**
 > Does not work on windows and I'm not trying too support this
 
-## TODO
- - [ ] user cobra for for a better cli experience
- - [ ] sub command to print paths that are ignored
- - [ ] create case sensative/insensative searching
- - [ ] exclude additional directories or patters
- - [ ] include specific patterns in the search path
- - [ ] switch to ignore all hidden files/directories
- - [x] can we create a worker pool instead of the number of initial directories
- - [x] cap the number of returned responses, say 1 (quit after the first match!)
- - [x] Auto-generate releases
- - [ ] cap the depth of the search
- - [x] use select statement with a fallback queue to prevent deadlock from happening
-
 ## Using
+### Usage
+Customise your search with the following flags
+
+```bash
+Usage: goFind [OPTIONS] <pattern> <path>
+  set pattern & path positionally or via flags
+  -c int
+        The maximum number of results to find (default -1)
+  -d string
+        The starting directory to check for files (default ".")
+  -i    perform a case insensative search
+  -p string
+        A pattern to check for within the file names
+  -q int
+        The max work queue size (default 512)
+  -v    print the version and build information
+  -w int
+        Number of workers (default -1)
+```
+
+## Contributing
 ### Build
 build with `go build -o gf main.go` and run with `./gf -d <starting-path> -p <pattern-to-match-on>`
 #### Requirements
@@ -40,18 +48,16 @@ You can use the [makefile](./Makefile) to build a production release with `make 
  - Make
  - Go 1.21+
 
-### Flags
-Customise your search with the following flags
-```bash
-Usage of ./gf:
-  -c int
-    	The maximum number of results to find (default -1)
-  -d string
-    	The starting directory to check for files (default ".")
-  -p string
-    	A pattern to check for within the file names
-  -q int
-    	The max work queue size (default 2048)
-  -w int
-    	Number of workers (default 8)
-```
+## Roadmap
+ - [x] can we create a worker pool instead of the number of initial directories
+ - [x] cap the number of returned responses, say 1 (quit after the first match!)
+ - [x] Auto-generate releases
+ - [x] cap the depth of the search
+ - [x] use select statement with a fallback queue to prevent deadlock from happening
+ - [x] use postional args or flags to set the pattern/path
+ - [ ] Add flag to print which paths will be ignored
+ - [ ] create case sensative/insensative searching
+ - [ ] exclude additional directories or patters
+ - [ ] include specific patterns in the search path
+ - [ ] switch to ignore all hidden files/directories
+ - [ ] look for `.gitignore` files and use contents to build ignored patterns

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"flag"
+	"runtime"
+)
+
+// Config the programs configuration used to set behavior
+type Config struct {
+	QueueSize   int
+	MaxResults  int
+	Workers     int
+	Dir         string
+	Pattern     string
+	Insensative bool
+	Version     bool
+}
+
+func parseCLI() *Config {
+	//The number of workers. If there are more workers the system can read from
+	//the work queue more often and a larger queue is not required.
+	workers := flag.Int("w", -1, "Number of workers")
+	//If the queue overflows we'll use a slice to store work which might slow the system
+	queueSize := flag.Int("q", 512, "The max work queue size")
+	maxResults := flag.Int("c", -1, "The maximum number of results to find")
+	dir := flag.String("d", ".", "The starting directory to check for files")
+	pattern := flag.String("p", "", "A pattern to check for within the file names")
+	insensative := flag.Bool("i", true, "perform a case insensative search")
+	v := flag.Bool("v", false, "print the version and build information")
+	flag.Parse()
+
+	p := *pattern
+	if p == "" {
+		p = flag.Arg(0)
+	}
+
+	w := *workers
+	if *workers <= 0 {
+		// magic 2, anecdotal evidence of better performance over NumCPU
+		w = runtime.NumCPU() + 2
+	}
+
+	//Only for OSX/Linux, sorry windows
+	//Remove any trailing slashes in the path
+	if (*dir)[len(*dir)-1:] == "/" {
+		*dir = string((*dir)[0 : len(*dir)-1])
+	}
+
+	return &Config{
+		QueueSize:   *queueSize,
+		MaxResults:  *maxResults,
+		Workers:     w,
+		Dir:         *dir,
+		Pattern:     p,
+		Insensative: *insensative,
+		Version:     *v,
+	}
+}

--- a/cli.go
+++ b/cli.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
 	"runtime"
 )
 
@@ -16,7 +18,22 @@ type Config struct {
 	Version     bool
 }
 
-func parseCLI() *Config {
+// myUsage overwrite default usage message from ./<bin> --help
+func myUsage() {
+	bin := "gof"
+	if len(os.Args) > 0 {
+		bin = os.Args[0]
+	}
+
+	fmt.Printf("Usage: %s [OPTIONS] <pattern> <path>\n", bin)
+	fmt.Println("  set pattern & path positionally or via flags")
+	flag.PrintDefaults()
+}
+
+// parseArgs all arguments from the user to use with the program
+func parseArgs() *Config {
+	flag.Usage = myUsage
+
 	//The number of workers. If there are more workers the system can read from
 	//the work queue more often and a larger queue is not required.
 	workers := flag.Int("w", -1, "Number of workers")
@@ -25,7 +42,7 @@ func parseCLI() *Config {
 	maxResults := flag.Int("c", -1, "The maximum number of results to find")
 	dir := flag.String("d", ".", "The starting directory to check for files")
 	pattern := flag.String("p", "", "A pattern to check for within the file names")
-	insensative := flag.Bool("i", true, "perform a case insensative search")
+	insensative := flag.Bool("i", false, "perform a case insensative search")
 	v := flag.Bool("v", false, "print the version and build information")
 	flag.Parse()
 
@@ -38,6 +55,10 @@ func parseCLI() *Config {
 	if *workers <= 0 {
 		// magic 2, anecdotal evidence of better performance over NumCPU
 		w = runtime.NumCPU() + 2
+	}
+
+	if *dir == "." && flag.Arg(1) != "" {
+		*dir = flag.Arg(1)
 	}
 
 	//Only for OSX/Linux, sorry windows

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func printBuildInfo() {
 }
 
 func main() {
-	cfg := parseCLI()
+	cfg := parseArgs()
 	if cfg.Version {
 		printBuildInfo()
 		return
@@ -35,6 +35,10 @@ func main() {
 	if cfg.Pattern == "" {
 		fmt.Println("No pattern found, please provide a search pattern")
 		return
+	}
+
+	if cfg.Insensative {
+		fmt.Println("WARN: case insensative search is not yet supported")
 	}
 
 	printCh := make(chan string, cfg.Workers)

--- a/search.go
+++ b/search.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+func showResults(ch chan string, limit *int) {
+	if *limit > 0 {
+		n := 0
+		for item := range ch {
+			fmt.Println(item)
+			n++
+			if n >= *limit {
+				return
+			}
+		}
+		return
+	}
+
+	for item := range ch {
+		fmt.Println(item)
+	}
+}
+
+func dirChecker(in chan int, work chan string) {
+	n := 1
+	for i := range in {
+		n += i
+		if n <= 0 {
+			close(work)
+			return
+		}
+	}
+}
+
+func createWorkerPool(p string, in chan string, failover chan string, results chan string, cnt chan int, w int) {
+	var wg sync.WaitGroup
+	for i := 0; i < w; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			search(p, in, failover, results, cnt)
+		}()
+	}
+	wg.Wait()
+	close(results)
+}
+
+func search(pattern string, in chan string, failover chan string, out chan string, cnt chan int) {
+	for path := range in {
+		items, err := os.ReadDir(path)
+		if err != nil {
+			fmt.Println("Error reading the directory", path)
+			fmt.Println(err)
+			cnt <- -1
+		}
+	ItemSearch:
+		for _, item := range items {
+			if item.IsDir() {
+				//Don't dive into directories I don't care about
+				for _, p := range IGNORE_PATHS {
+					if p == item.Name() {
+						continue ItemSearch
+					}
+				}
+				subPath := fmt.Sprintf("%s/%s", path, item.Name())
+				cnt <- 1
+				select {
+				case in <- subPath:
+				case failover <- subPath:
+				}
+			}
+			//Always check if the name of the thing matches pattern, including directory names
+			if strings.Contains(item.Name(), pattern) {
+				//subPath is repeated but no point in creating an allocation if not required
+				subPath := fmt.Sprintf("%s/%s", path, item.Name())
+				out <- subPath
+			}
+
+		}
+		//We finished reading everything in the dir, tell the accounted we finished
+		cnt <- -1
+	}
+}
+
+func handleFailover(work, fail chan string) {
+	var q []string
+	for {
+		task := <-fail
+		q = append(q, task)
+		//TODO: Add verbose logging here so users can check if the failover was used
+		for {
+			select {
+			case work <- q[0]:
+				q = q[1:]
+			case task := <-fail:
+				q = append(q, task)
+			default:
+			}
+			//I don't know if we'll get an issue with `work <- q[0]` unless we have this
+			if len(q) == 0 {
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
# What does this Pull Request Do?
It allows patterns to be passed as a positional argument in addition to a flag. 

```bash
$ gof foo
```

# Why should this be added?
This should be added because it's faster than than setting a flag. If I'm accepting all of the defaults then this is the smoothest usage
